### PR TITLE
Clarify inversion of dual Y-axis motors

### DIFF
--- a/grbl/defaults.h
+++ b/grbl/defaults.h
@@ -394,7 +394,7 @@
   #define DEFAULT_SPINDLE_RPM_MIN 0.0 // rpm
   #define DEFAULT_STEP_PULSE_MICROSECONDS 10
   #define DEFAULT_STEPPING_INVERT_MASK 0
-  #define DEFAULT_DIRECTION_INVERT_MASK ((1<<X_AXIS)|(1<<Y_AXIS)|(1<<Z_AXIS))
+  #define DEFAULT_DIRECTION_INVERT_MASK ((1<<Y_AXIS)|(1<<N_AXIS)|(1<<Z_AXIS)) // N_AXIS is a misnomer, it's to invert the secondary, independent y-axis motor.
   #define DEFAULT_STEPPER_IDLE_LOCK_TIME 255 // msec (0-254, 255 keeps steppers enabled)
   #define DEFAULT_STATUS_REPORT_MASK 1 // MPos enabled
   #define DEFAULT_JUNCTION_DEVIATION 0.02 // mm

--- a/grbl/grbl.h
+++ b/grbl/grbl.h
@@ -23,7 +23,7 @@
 
 // Grbl versioning system
 #define GRBL_VERSION "1.1h-XCP"
-#define GRBL_VERSION_BUILD "20200803"
+#define GRBL_VERSION_BUILD "20200804"
 
 #define X_CARVE_PRO
 


### PR DESCRIPTION
Assuming this actually is a typo and we need to invert the x-axis motor direction. If not, the `N_AXIS` bit field should be removed as it's doing nothing. Double checking w/ Sumanth to clarify the wiring.