### PR TITLE
avrdude flash scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ for both flashing (`grbl.hex`) and compiling instructions.
 
 Flashing the `grbl.bootloader.hex` is more invovled as you need to setup an ISP to erase and write the full program memory. One relatively easy approach is to use another [Arduino as an ISP](https://www.arduino.cc/en/Tutorial/BuiltInExamples/ArduinoISP) but this does require a small bit of wiring and uploading an custom ISP program to said Arduino.
 
+There's also `flash-grbl.sh` and `flash-combined.sh` that wrap the appropriate `avrdude` command for the respective hex file.
+
 ## Releases
 
 There are automated builds setup on CircleCI for this repo. Currently they are run on PR requests and when changes are merged to master. Upon success, the firmware binaries (`grbl.hex` and `grbl.bootloader.hex`) are uploaded as a CircleCI artifact. Here's an [example of the artifacts tab](https://app.circleci.com/pipelines/github/inventables/grbl-xcp/14/workflows/925d508a-5c7a-4c85-98ef-4215e30a4f6f/jobs/15/artifacts) from a `master` branch build

--- a/flash-combined.sh
+++ b/flash-combined.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+HEX_FILE=grbl.bootloader.hex
+PORT=$(ls /dev/cu.usb*) # This is just a heuristic
+
+ARDUINO_TOOLS=/Applications/Arduino.app/Contents/Java/hardware/tools/avr
+# Alternatively if installed per-user
+#ARDUINO_TOOLS=${HOME}/Applications/Arduino.app/Contents/Java/hardware/tools/avr
+
+${ARDUINO_TOOLS}/bin/avrdude -v \
+ -C ${ARDUINO_TOOLS}/etc/avrdude.conf \
+ -p atmega2560 \
+ -c stk500v1 \
+ -P ${PORT} \
+ -b 19200 \
+ -U flash:w:${HEX_FILE}:i
+

--- a/flash-grbl.sh
+++ b/flash-grbl.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+HEX_FILE=grbl.hex
+PORT=$(ls /dev/cu.usb*) # This is just a heuristic
+
+ARDUINO_TOOLS=/Applications/Arduino.app/Contents/Java/hardware/tools/avr
+# Alternatively if installed per-user
+#ARDUINO_TOOLS=${HOME}/Applications/Arduino.app/Contents/Java/hardware/tools/avr
+
+${ARDUINO_TOOLS}/bin/avrdude -v \
+ -C ${ARDUINO_TOOLS}/etc/avrdude.conf \
+ -p atmega2560 \
+ -c wiring -D \
+ -P ${PORT} \
+ -b 115200 \
+ -U flash:w:${HEX_FILE}:i
+


### PR DESCRIPTION
Couple of scripts that wrap `avrdude` for flashing grbl and the combined bootloader firmware.