### PR TITLE
echo: Convert to runtime setting

### DIFF
--- a/grbl/config.h
+++ b/grbl/config.h
@@ -374,7 +374,7 @@
 // NOTE: Only use this for debugging purposes!! When echoing, this takes up valuable resources and can effect
 // performance. If absolutely needed for normal operation, the serial write buffer should be greatly increased
 // to help minimize transmission waiting within the serial write protocol.
-// #define REPORT_ECHO_LINE_RECEIVED // Default disabled. Uncomment to enable.
+#define REPORT_ECHO_LINE_RECEIVED // Default disabled. Uncomment to enable.
 
 // Minimum planner junction speed. Sets the default minimum junction speed the planner plans to at
 // every buffer block junction, except for starting from rest and end of the buffer, which are always

--- a/grbl/config.h
+++ b/grbl/config.h
@@ -367,14 +367,6 @@
 // NOTE: Requires USE_SPINDLE_DIR_AS_ENABLE_PIN to be enabled.
 // #define SPINDLE_ENABLE_OFF_WITH_ZERO_SPEED // Default disabled. Uncomment to enable.
 
-// With this enabled, Grbl sends back an echo of the line it has received, which has been pre-parsed (spaces
-// removed, capitalized letters, no comments) and is to be immediately executed by Grbl. Echoes will not be
-// sent upon a line buffer overflow, but should for all normal lines sent to Grbl. For example, if a user
-// sendss the line 'g1 x1.032 y2.45 (test comment)', Grbl will echo back in the form '[echo: G1X1.032Y2.45]'.
-// NOTE: Only use this for debugging purposes!! When echoing, this takes up valuable resources and can effect
-// performance. If absolutely needed for normal operation, the serial write buffer should be greatly increased
-// to help minimize transmission waiting within the serial write protocol.
-#define REPORT_ECHO_LINE_RECEIVED // Default disabled. Uncomment to enable.
 
 // Minimum planner junction speed. Sets the default minimum junction speed the planner plans to at
 // every buffer block junction, except for starting from rest and end of the buffer, which are always

--- a/grbl/grbl.h
+++ b/grbl/grbl.h
@@ -23,7 +23,7 @@
 
 // Grbl versioning system
 #define GRBL_VERSION "1.1h-XCP"
-#define GRBL_VERSION_BUILD "20200908-echo"
+#define GRBL_VERSION_BUILD "20201012"
 
 #define X_CARVE_PRO
 

--- a/grbl/grbl.h
+++ b/grbl/grbl.h
@@ -23,7 +23,7 @@
 
 // Grbl versioning system
 #define GRBL_VERSION "1.1h-XCP"
-#define GRBL_VERSION_BUILD "20200804"
+#define GRBL_VERSION_BUILD "20200908-echo"
 
 #define X_CARVE_PRO
 

--- a/grbl/protocol.c
+++ b/grbl/protocol.c
@@ -82,9 +82,9 @@ void protocol_main_loop()
         if (sys.abort) { return; } // Bail to calling function upon system abort
 
         line[char_counter] = 0; // Set string termination character.
-        #ifdef REPORT_ECHO_LINE_RECEIVED
+        if (bit_istrue(settings.status_report_mask,BITFLAG_REPORT_ECHO_LINE)) {
           report_echo_line_received(line);
-        #endif
+        }
 
         // Direct and execute one line of formatted input, and report status of execution.
         if (line_flags & LINE_FLAG_OVERFLOW) {

--- a/grbl/report.c
+++ b/grbl/report.c
@@ -189,7 +189,7 @@ void report_grbl_settings() {
   report_util_uint8_setting(4,bit_istrue(settings.flags,BITFLAG_INVERT_ST_ENABLE));
   report_util_uint8_setting(5,bit_istrue(settings.flags,BITFLAG_INVERT_LIMIT_PINS));
   report_util_uint8_setting(6,bit_istrue(settings.flags,BITFLAG_INVERT_PROBE_PIN));
-  report_util_uint8_setting(10,settings.status_report_mask);
+  report_util_uint8_setting(10,settings.status_report_mask&BITFLAG_RT_STATUS_MASK);
   report_util_float_setting(11,settings.junction_deviation,N_DECIMAL_SETTINGVALUE);
   report_util_float_setting(12,settings.arc_tolerance,N_DECIMAL_SETTINGVALUE);
   report_util_uint8_setting(13,bit_istrue(settings.flags,BITFLAG_REPORT_INCHES));
@@ -208,6 +208,8 @@ void report_grbl_settings() {
   #else
     report_util_uint8_setting(32,0);
   #endif
+  report_util_uint8_setting(40,bit_istrue(settings.status_report_mask,BITFLAG_REPORT_ECHO_LINE));
+
   // Print axis settings
   uint8_t idx, set_idx;
   uint8_t val = AXIS_SETTINGS_START_VAL;

--- a/grbl/serial.h
+++ b/grbl/serial.h
@@ -27,10 +27,15 @@
   #define RX_BUFFER_SIZE 128
 #endif
 #ifndef TX_BUFFER_SIZE
-  #ifdef USE_LINE_NUMBERS
-    #define TX_BUFFER_SIZE 112
+  #ifdef REPORT_ECHO_LINE_RECEIVED
+    // Thankfully on the Mega we have a lot more space
+    #define TX_BUFFER_SIZE 1024
   #else
-    #define TX_BUFFER_SIZE 104
+    #ifdef USE_LINE_NUMBERS
+      #define TX_BUFFER_SIZE 112
+    #else
+      #define TX_BUFFER_SIZE 104
+    #endif
   #endif
 #endif
 

--- a/grbl/serial.h
+++ b/grbl/serial.h
@@ -27,8 +27,8 @@
   #define RX_BUFFER_SIZE 128
 #endif
 #ifndef TX_BUFFER_SIZE
-  #ifdef REPORT_ECHO_LINE_RECEIVED
-    // Thankfully on the Mega we have a lot more space
+  #ifdef X_CARVE_PRO
+    // Targets an ATMega2560 so has sufficient space
     #define TX_BUFFER_SIZE 1024
   #else
     #ifdef USE_LINE_NUMBERS

--- a/grbl/settings.c
+++ b/grbl/settings.c
@@ -266,7 +266,10 @@ uint8_t settings_store_global_setting(uint8_t parameter, float value) {
         else { settings.flags &= ~BITFLAG_INVERT_PROBE_PIN; }
         probe_configure_invert_mask(false);
         break;
-      case 10: settings.status_report_mask = int_value&BITFLAG_RT_STATUS_MASK; break;
+      case 10:
+        settings.status_report_mask &= ~BITFLAG_RT_STATUS_MASK;
+        settings.status_report_mask |= int_value&BITFLAG_RT_STATUS_MASK;
+        break;
       case 11: settings.junction_deviation = value; break;
       case 12: settings.arc_tolerance = value; break;
       case 13:

--- a/grbl/settings.h
+++ b/grbl/settings.h
@@ -27,7 +27,7 @@
 
 // Version of the EEPROM data. Will be used to migrate existing data from older versions of Grbl
 // when firmware is upgraded. Always stored in byte 0 of eeprom
-#define SETTINGS_VERSION 10  // NOTE: Check settings_reset() when moving to next version.
+#define SETTINGS_VERSION 11  // NOTE: Check settings_reset() when moving to next version.
 
 // Define bit flag masks for the boolean settings in settings.flag.
 #define BIT_REPORT_INCHES      0
@@ -51,6 +51,15 @@
 // Define status reporting boolean enable bit flags in settings.status_report_mask
 #define BITFLAG_RT_STATUS_POSITION_TYPE     bit(0)
 #define BITFLAG_RT_STATUS_BUFFER_STATE      bit(1)
+#define BITFLAG_RT_STATUS_MASK              (BITFLAG_RT_STATUS_POSITION_TYPE|BITFLAG_RT_STATUS_BUFFER_STATE)
+// With this enabled, Grbl sends back an echo of the line it has received, which has been pre-parsed (spaces
+// removed, capitalized letters, no comments) and is to be immediately executed by Grbl. Echoes will not be
+// sent upon a line buffer overflow, but should for all normal lines sent to Grbl. For example, if a user
+// sends the line 'g1 x1.032 y2.45 (test comment)', Grbl will echo back in the form '[echo: G1X1.032Y2.45]'.
+// NOTE: Only use this for debugging purposes!! When echoing, this takes up valuable resources and can effect
+// performance. If absolutely needed for normal operation, the serial write buffer should be greatly increased
+// to help minimize transmission waiting within the serial write protocol.
+#define BITFLAG_REPORT_ECHO_LINE            bit(7)
 
 // Define settings restore bitflags.
 #define SETTINGS_RESTORE_DEFAULTS bit(0)
@@ -96,7 +105,9 @@ typedef struct {
   uint8_t step_invert_mask;
   uint8_t dir_invert_mask;
   uint8_t stepper_idle_lock_time; // If max value 255, steppers do not disable.
+
   uint8_t status_report_mask; // Mask to indicate desired report data.
+
   float junction_deviation;
   float arc_tolerance;
 


### PR DESCRIPTION
Converts the `REPORT_ECHO_LINE_RECEIVED` compile-time option to a runtime setting that can be enabled via `$40`.

The existing status report mask is used to store this in bit-7 since that currently only requires 2-bits. This approach avoids expanding the settings size used in EEPROM. A trivial migration from version 10 => 11 of settings has been written to ensure this isn't set on upgrade.

Additionally, the serial transmit buffer size has been increased to 1k as recommended by the prior compile-time option comment. It may be possible to backport to the X-Controller (e.g the ATmega328p) if we skipped this part of the change.

Tested the upgrade path by setting `$10=255` on an older version of the firmware, flashing this version and ensuring that `$40=0` and `$10=3`.

See https://github.com/inventables/easel/issues/5623. This supersedes #4