### PR TITLE
bootloader: Custom build identifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,14 +92,15 @@ grbl.hex: $(BUILDDIR)/main.elf
 	rm -f grbl.hex
 	avr-objcopy -j .text -j .data -O ihex $(BUILDDIR)/main.elf grbl.hex
 	avr-size --format=berkeley $(BUILDDIR)/main.elf
+
+grbl.bootloader.hex: $(BUILDDIR)/main.elf grbl.hex bootloader/stk500boot_v2_mega2560.hex
+	./bootloader/combine.sh $^ $@
+
 # If you have an EEPROM section, you must also create a hex file for the
 # EEPROM and add it to the "flash" target.
 
-grbl.bootloader.hex: grbl.hex bootloader/stk500boot_v2_mega2560.hex
-	srec_cat -Output grbl.bootloader.hex -Intel grbl.hex -Intel bootloader/stk500boot_v2_mega2560.hex -Intel
-
 # Targets for code debugging and analysis:
-disasm:	main.elf
+disasm:	$(BUILDDIR)/main.elf
 	avr-objdump -d $(BUILDDIR)/main.elf
 
 cpp:

--- a/bootloader/combine.sh
+++ b/bootloader/combine.sh
@@ -1,0 +1,45 @@
+#/usr/bin/env bash
+
+set -eu
+
+ELF=$1
+GRBL=$2
+BOOT=$3
+OUT=$4
+
+# Creates a combined bootloader, tweaking the version identifer. The last
+# byte of the GRBL_VERSION_BUILD macro is tweaked to differentiate hex
+# files with and w/out a bootloader based on the `$I` output.
+#
+# Lookup the address of the `build_info_ver` symbol
+#
+#   avr-objdump -t build/main.elf | grep build_info_ver
+#   00000246 l     O .text	00000019 build_info_ver
+#
+# With the address (column 1) and size (column 5) we can find the target
+# byte of our string which is formatted as such:
+#
+#   build_info_ver = "[VER:" GRBL_VERSION "." GRBL_VERSION_BUILD ":"
+#
+# The `base+len-3` skips the implied null terminator and final colon
+#
+ADDR=$(avr-objdump -t $ELF | grep build_info_ver |
+    awk '{ base= ("0x" $1) + 0; len = ("0x" $5) + 0; print base+len-3; }')
+
+START=$(printf "0x%X\n" $ADDR)
+END=$(printf "0x%X\n" $(($ADDR+1)))
+
+# 98 is `b` in ASCII (`a` for standalone Grbl)
+srec_cat -Output $OUT -Intel \
+    -generate $START $END -constant 98 \
+    $GRBL -Intel -exclude $START $END \
+    $BOOT -Intel
+
+# Check the before/after version with adress and size from avr-objdump
+#
+# > srec_cat -Output - -Hex_Dump grbl.hex -Intel -crop 0x246 0x25e
+# 00000240:                   5B 56 45 52 3A 31 2E 31 68 2D  #      [VER:1.1h-
+# 00000250: 58 43 50 2E 32 30 32 30 31 30 31 34 61 3A        #XCP.20201014a:
+# > srec_cat -Output - -Hex_Dump grbl.bootloader.hex -Intel -crop 0x246 0x25e
+# 00000240:                   5B 56 45 52 3A 31 2E 31 68 2D  #      [VER:1.1h-
+# 00000250: 58 43 50 2E 32 30 32 30 31 30 31 34 62 3A        #XCP.20201014b:

--- a/grbl/grbl.h
+++ b/grbl/grbl.h
@@ -23,7 +23,8 @@
 
 // Grbl versioning system
 #define GRBL_VERSION "1.1h-XCP"
-#define GRBL_VERSION_BUILD "20201012"
+// The `a` suffix is flipped to `b` for the combined bootloader build
+#define GRBL_VERSION_BUILD "20201014a"
 
 #define X_CARVE_PRO
 

--- a/grbl/report.c
+++ b/grbl/report.c
@@ -368,10 +368,12 @@ void report_execute_startup_message(char *line, uint8_t status_code)
   report_status_message(status_code);
 }
 
+static const char build_info_ver[] PROGMEM = "[VER:" GRBL_VERSION "." GRBL_VERSION_BUILD ":";
+
 // Prints build info line
 void report_build_info(char *line)
 {
-  printPgmString(PSTR("[VER:" GRBL_VERSION "." GRBL_VERSION_BUILD ":"));
+  printPgmString(&build_info_ver[0]);
   printString(line);
   report_util_feedback_line_feed();
   printPgmString(PSTR("[OPT:")); // Generate compile-time build option list


### PR DESCRIPTION
Adds a final character suffix to `GRBL_VERSION_BUILD` that is tweaked in the grbl+bootloader hexfile. Uses `a` for the standalone Grbl build and `b` for the combined build. This makes it possible to check at the factory via `$I` that the bootloader variant is flashed.

The version string was converted to an actual variable rather then an inline literal. This makes it easier to lookup the address via a named symbol with `avr-objdump -t` so that it can be modified post compile/link. (Technically the inline string had a name via the [`PSTR` macro](https://www.avrfreaks.net/comment/297548#comment-297548) but gets an auto-generated suffix, e.g. `__c.1234`).

I've included a fair number of comments inline since this can otherwise appear to be some obtuse compiler magic.

**Grbl-only**
```
$ srec_cat -Output - -Hex_Dump grbl.hex -Intel -crop 0x246 0x25e
00000240:                   5B 56 45 52 3A 31 2E 31 68 2D  #      [VER:1.1h-
00000250: 58 43 50 2E 32 30 32 30 31 30 31 34 61 3A        #XCP.20201014a:
```

**Grbl+bootloader**
```
$ srec_cat -Output - -Hex_Dump grbl.bootloader.hex -Intel -crop 0x246 0x25e
00000240:                   5B 56 45 52 3A 31 2E 31 68 2D  #      [VER:1.1h-
00000250: 58 43 50 2E 32 30 32 30 31 30 31 34 62 3A        #XCP.20201014b:
```