### PR TITLE
Reduce x-axis default acceleration

### DIFF
--- a/grbl/defaults.h
+++ b/grbl/defaults.h
@@ -384,9 +384,9 @@
   #define DEFAULT_X_MAX_RATE 7620.0 // mm/min
   #define DEFAULT_Y_MAX_RATE 7620.0 // mm/min
   #define DEFAULT_Z_MAX_RATE 2540.0 // mm/min
-  #define DEFAULT_X_ACCELERATION (500.0*60*60) // 25*60*60 mm/min^2 = 25 mm/sec^2
-  #define DEFAULT_Y_ACCELERATION (350.0*60*60) // 25*60*60 mm/min^2 = 25 mm/sec^2
-  #define DEFAULT_Z_ACCELERATION (500.0*60*60) // 25*60*60 mm/min^2 = 25 mm/sec^2
+  #define DEFAULT_X_ACCELERATION (250.0*60*60) // 250*60*60 mm/min^2 = 250 mm/sec^2
+  #define DEFAULT_Y_ACCELERATION (350.0*60*60) // 350*60*60 mm/min^2 = 350 mm/sec^2
+  #define DEFAULT_Z_ACCELERATION (500.0*60*60) // 500*60*60 mm/min^2 = 500 mm/sec^2
   #define DEFAULT_X_MAX_TRAVEL 1219.2 // mm NOTE: Must be a positive value.
   #define DEFAULT_Y_MAX_TRAVEL 1219.2 // mm NOTE: Must be a positive value.
   #define DEFAULT_Z_MAX_TRAVEL 130.0 // mm NOTE: Must be a positive value.

--- a/grbl/grbl.h
+++ b/grbl/grbl.h
@@ -24,7 +24,8 @@
 // Grbl versioning system
 #define GRBL_VERSION "1.1h-XCP"
 // The `a` suffix is flipped to `b` for the combined bootloader build
-#define GRBL_VERSION_BUILD "20201014a"
+// See also https://github.com/inventables/grbl-xcp/pull/8
+#define GRBL_VERSION_BUILD "20210907a"
 
 #define X_CARVE_PRO
 


### PR DESCRIPTION
Sets the default acceleration to 250 mm/sec^2 for the x-axis. The prior default of 500 mm/sec^2 could cause skipped steps on the XCP.