### PR TITLE
Stop the spindle when pause button is pressed

### DIFF
--- a/grbl/config.h
+++ b/grbl/config.h
@@ -557,7 +557,7 @@
 
 // Configure options for the parking motion, if enabled.
 #define PARKING_AXIS Z_AXIS // Define which axis that performs the parking motion
-#define PARKING_TARGET -25.4 // Parking axis target. In mm, as machine coordinate [-max_travel,0].
+#define PARKING_TARGET -5.0 // Parking axis target. In mm, as machine coordinate [-max_travel,0].
 #define PARKING_RATE 500.0 // Parking fast rate after pull-out in mm/min.
 #define PARKING_PULLOUT_RATE 100.0 // Pull-out/plunge slow feed rate in mm/min.
 #define PARKING_PULLOUT_INCREMENT 5.0 // Spindle pull-out and plunge distance in mm. Incremental distance.

--- a/grbl/config.h
+++ b/grbl/config.h
@@ -557,7 +557,7 @@
 
 // Configure options for the parking motion, if enabled.
 #define PARKING_AXIS Z_AXIS // Define which axis that performs the parking motion
-#define PARKING_TARGET -5.0 // Parking axis target. In mm, as machine coordinate [-max_travel,0].
+#define PARKING_TARGET -25.4 // Parking axis target. In mm, as machine coordinate [-max_travel,0].
 #define PARKING_RATE 500.0 // Parking fast rate after pull-out in mm/min.
 #define PARKING_PULLOUT_RATE 100.0 // Pull-out/plunge slow feed rate in mm/min.
 #define PARKING_PULLOUT_INCREMENT 5.0 // Spindle pull-out and plunge distance in mm. Incremental distance.

--- a/grbl/cpu_map.h
+++ b/grbl/cpu_map.h
@@ -314,7 +314,7 @@
   #define CONTROL_RESET_BIT         0
   #define CONTROL_FEED_HOLD_BIT     1
   #define CONTROL_CYCLE_START_BIT   2
-  #define CONTROL_SAFETY_DOOR_BIT   3  // NOTE: Safety door is shared with feed hold. Enabled by config define.
+  #define CONTROL_SAFETY_DOOR_BIT   1  // NOTE: Safety door is shared with feed hold. Enabled by config define.
   #define CONTROL_INT               PCIE1  // Pin change interrupt enable pin
   #define CONTROL_INT_vect          PCINT1_vect
   #define CONTROL_PCMSK             PCMSK1 // Pin change interrupt register

--- a/grbl/grbl.h
+++ b/grbl/grbl.h
@@ -22,7 +22,7 @@
 #define grbl_h
 
 // Grbl versioning system
-#define GRBL_VERSION "1.1h-XCP.20220314a"
+#define GRBL_VERSION "1.1h-XCPd.20220610a"
 
 #define X_CARVE_PRO
 

--- a/grbl/grbl.h
+++ b/grbl/grbl.h
@@ -22,7 +22,7 @@
 #define grbl_h
 
 // Grbl versioning system
-#define GRBL_VERSION "1.1h-XCPd.20220610a"
+#define GRBL_VERSION "1.1h-XCPd.20230214a"
 
 #define X_CARVE_PRO
 


### PR DESCRIPTION
Changes the pause behavior to de-energeize the spindle when pause button is physically pressed.
Retract 1" above surface when parked during feed hold.

This will require changes in Easel to adjust the realtime command for XCP to be `safety door` instead of `feed hold` as explained in [grbl wiki](https://github.com/gnea/grbl/wiki/Grbl-v1.1-Commands#grbl-v11-realtime-commands)
Wiring is using the same pin as feed hold interrupt, and that's the default behavior of [unmodifed grbl](https://github.com/gnea/grbl/blob/bfb67f0c7963fe3ce4aaf8a97f9009ea5a8db36e/grbl/cpu_map.h#L85). What that means is pressing the pause button on HMI will be treated the same as momentarily opening, and shortly closing, the non-existent door. grbl does require a manual override to restart the spindle as safety features, even if doors are closed again (think you pushing on the door switch by accident when working on opened case on a machine).

What that means is after machine has the door pin triggered, and feed is hold, spindle is de-energized and retracted, users do need to either press the Resume button on the HMI or in Easel.  

After pause and retraction user has to wait 4 seconds to resume the carve according to https://github.com/inventables/grbl-xcp/blob/564ecb2638e652a15de49f982a186d9cf1c44aef/grbl/config.h#L179
I found this to not be the case and with my machine I had to wait closer to 10-15s to resume the carve. Pressing the button would not resume the carve. This might have to do with physical limitations of the spindle on X-Carve Pro. It is not a huge deal IMHO as it takes a couple of seconds for machine to retract, and to wind down. Actual testing with other units is necessary, this could be just a timing issue with my unit.